### PR TITLE
build(docker): Replace ubuntu:jammy with graalvm-native-image-base

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -17,7 +17,7 @@ WORKDIR /build
 COPY . .
 RUN ./mvnw -B -ntp clean package -DskipTests -Pnative
 
-FROM ubuntu:jammy
+FROM cgr.dev/chainguard/graalvm-native-image-base
 COPY --from=build /build/distribution/native/target/hawkeye-native /bin/
 WORKDIR /github/workspace/
 ENTRYPOINT ["/bin/hawkeye-native"]


### PR DESCRIPTION
This closes #17.