### PR TITLE
build(docker): Use new name for GraalVM base image

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -17,7 +17,7 @@ WORKDIR /build
 COPY . .
 RUN ./mvnw -B -ntp clean package -DskipTests -Pnative
 
-FROM cgr.dev/chainguard/graalvm-native-image-base
+FROM cgr.dev/chainguard/graalvm-native
 COPY --from=build /build/distribution/native/target/hawkeye-native /bin/
 WORKDIR /github/workspace/
 ENTRYPOINT ["/bin/hawkeye-native"]


### PR DESCRIPTION
We have renamed the Chainguard image, so this PR is to reflect the new name.

The old name should still be available for some time, but will not be receiving updates anymore.

https://github.com/chainguard-images/images/tree/main/images/graalvm-native

cc @tisonkun