### PR TITLE
fix: annontate for fields with default value

### DIFF
--- a/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/config/ConfigFileModel.java
+++ b/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/config/ConfigFileModel.java
@@ -45,8 +45,10 @@ class ConfigFileModel {
     private final List<String> includes = Collections.emptyList();
     @Builder.Default
     private final List<String> excludes = Collections.emptyList();
+    @Builder.Default
     private final List<String> keywords = Collections.singletonList("copyright");
     @Builder.Default
     private final Map<String, String> properties = Collections.emptyMap();
-    private final MappingsModel mapping;
+    @Builder.Default
+    private final MappingsModel mapping = new MappingsModel();
 }


### PR DESCRIPTION
* `keywords` otherwise fail if specified;
* `mapping` otherwise null if not specified.