### PR TITLE
feat(maven): improve experience for multimodule project

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,42 +62,7 @@ docker run -it --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye check
 
 > :warning: `hawkeye-maven-plugin` is available since 3.3.0, but it's still Alpha which means that the API is subject to change before stable. Mainly, the configuration options may change.
 
-You can integrate HawkEye's functionality with Maven Plugin:
-
-```xml
-<plugin>
-    <groupId>io.korandoru.hawkeye</groupId>
-    <artifactId>hawkeye-maven-plugin</artifactId>
-    <version>${hawkeye.version}</version>
-</plugin>
-```
-
-The plugin provides three goals:
-
-* `check`: Check license headers.
-* `format`: Format license headers (auto-fix all files that failed the check).
-* `remove`: Remove license headers.
-
-With the plugin properly configured, you can run a specific goal as (take `check` as an example):
-
-```shell
-mvn hawkeye:check
-```
-
-You can configure a customized location of the `licenserc.toml` file as:
-
-```xml
-<plugin>
-    <groupId>io.korandoru.hawkeye</groupId>
-    <artifactId>hawkeye-maven-plugin</artifactId>
-    <version>${hawkeye.version}</version>
-    <configuration>
-      <config>${...}</config>
-    </configuration>
-</plugin>
-```
-
-... the default location is `${project.basedir}/licenserc.toml`.
+Read the [dedicated README](hawkeye-maven-plugin/README.md) for HawkEye Maven Plugin.
 
 ### Executable JAR
 

--- a/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/config/HawkEyeConfig.java
+++ b/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/config/HawkEyeConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.dataformat.toml.TomlMapper;
 import io.korandoru.hawkeye.core.mapping.Mapping;
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,6 +72,12 @@ public class HawkEyeConfig {
     public static final class Builder {
         private Builder() {
             // always use #of methods
+        }
+
+        public HawkEyeConfig.Builder addExcludes(List<String> excludes) {
+            this.excludes = new ArrayList<>(this.excludes);
+            this.excludes.addAll(excludes);
+            return this;
         }
 
         public HawkEyeConfig build() {

--- a/hawkeye-maven-plugin/README.md
+++ b/hawkeye-maven-plugin/README.md
@@ -1,0 +1,104 @@
+# HawkEye Maven Plugin
+
+## Usage
+
+You can integrate HawkEye's functionality with Maven Plugin:
+
+```xml
+<plugin>
+    <groupId>io.korandoru.hawkeye</groupId>
+    <artifactId>hawkeye-maven-plugin</artifactId>
+    <version>${hawkeye.version}</version>
+</plugin>
+```
+
+The plugin provides three goals:
+
+* `check`: Check license headers.
+* `format`: Format license headers (auto-fix all files that failed the check).
+* `remove`: Remove license headers.
+
+With the plugin properly configured, you can run a specific goal as (take `check` as an example):
+
+```shell
+mvn hawkeye:check
+```
+
+You can configure a customized location of the `licenserc.toml` file as:
+
+```xml
+<plugin>
+    <groupId>io.korandoru.hawkeye</groupId>
+    <artifactId>hawkeye-maven-plugin</artifactId>
+    <version>${hawkeye.version}</version>
+    <configuration>
+      <configLocation>${...}</configLocation>
+    </configuration>
+</plugin>
+```
+
+... the default location is `${project.basedir}/licenserc.toml`.
+
+## Verify
+
+The `check` goal is bind to the `verify` phase by default. If you'd like to do all verifications with a single `mvn verify`, you can add the HawkEye checks as:
+
+```xml
+<plugin>
+    <groupId>io.korandoru.hawkeye</groupId>
+    <artifactId>hawkeye-maven-plugin</artifactId>
+    <version>${hawkeye.version}</version>
+    <executions>
+    <execution>
+        <goals>
+            <goal>check</goal>
+        </goals>
+    </execution>
+    </executions>
+</plugin>
+```
+
+## Multimodule
+
+HawkEye is designed to run against a whole project but Maven plugin is configured to each module.
+
+That said, the default location of configuration file (`${project.basedir}/licenserc.toml`) will be resolved to different place due to each module has its own `${project.basedir}`. This is the same to the basedir of the execution.
+
+Below are two recommendations for configuring multimodule project.
+
+### Aggregator
+
+The HawkEye plugin provides an option named `aggregate` with which you can check the headers for all modules of your project.
+
+You can configure the plugin with `aggregate` for your parent `pom.xml`:
+
+```xml
+<plugin>
+    <groupId>io.korandoru.hawkeye</groupId>
+    <artifactId>hawkeye-maven-plugin</artifactId>
+    <version>${hawkeye.version}</version>
+    <configuration>
+        <aggregate>true</aggregate>
+    </configuration>
+</plugin>
+```
+
+... and properly skip all the submodules.
+
+You can also run as aggregator from the commandline:
+
+```shell
+mvn hawkeye:check -pl . -Daggregate=true
+```
+
+### Each module
+
+You can still configure the plugin executions for each module, but pay attention to the resolved value of `configLocation` and `baseDir`.
+
+> This means `aggregate=false` and the plugin will exclude submodules when running against a parent module.
+
+The default `configLocation` is `${project.basedir}/licenserc.toml` which requires a `licenserc.toml` per module. If you use one config file for all modules, you should change the config value to a fixed location. [directory-maven-plugin](https://github.com/jdcasey/directory-maven-plugin), `${maven.multiModuleProjectDirectory}`, or [MNG-7038](https://issues.apache.org/jira/browse/MNG-7038) can help.
+
+The default `basedir` is overwritten by `${project.basedir}`, which means the one configured in `licenserc.toml` is not used. This should often be the value you want, but you can still change the directory for each module.
+
+Be aware that this basedir is also the one for resolving `includes` and `excludes`. If a file is not properly included or excluded, think of the resolved value of `includes` and `excludes` pattens.

--- a/hawkeye-maven-plugin/pom.xml
+++ b/hawkeye-maven-plugin/pom.xml
@@ -36,14 +36,20 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven-core.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven-plugin-api.version}</version>
+            <version>${maven-core.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>${maven-plugin-annotation.version}</version>
+            <version>${maven-plugin-tools.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -53,7 +59,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>${maven-plugin-plugin.version}</version>
+                <version>${maven-plugin-tools.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/AbstractMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/AbstractMojo.java
@@ -25,9 +25,15 @@ import org.apache.maven.project.MavenProject;
 
 abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
     /**
+     * The base directory, in which to search for project files.
+     */
+    @Parameter(property = "hawkeye.basedir", defaultValue = "${project.basedir}", required = true)
+    public File basedir;
+
+    /**
      * Location of the `licenserc.toml` file.
      */
-    @Parameter(property = "hawkeye.configLocation", defaultValue = "${project.basedir}/licenserc.toml")
+    @Parameter(property = "hawkeye.configLocation", defaultValue = "${project.basedir}/licenserc.toml", required = true)
     public File configLocation;
 
     /**
@@ -54,6 +60,8 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
                 submodulesExcludes.add(module + "/**");
             }
         }
-        return HawkEyeConfig.of(configLocation).addExcludes(submodulesExcludes);
+        return HawkEyeConfig.of(configLocation)
+                .addExcludes(submodulesExcludes)
+                .baseDir(basedir.toPath());
     }
 }

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/AbstractMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/AbstractMojo.java
@@ -20,9 +20,15 @@ import java.io.File;
 import org.apache.maven.plugins.annotations.Parameter;
 
 abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
-    @Parameter(name = "config", alias = "cfg", defaultValue = "${project.basedir}/licenserc.toml")
+    /**
+     * Location of the `licenserc.toml` file.
+     */
+    @Parameter(name = "config", defaultValue = "${project.basedir}/licenserc.toml")
     public File config;
 
+    /**
+     * Whether to do the real formatting or removal.
+     */
     @Parameter(name = "dryRun", defaultValue = "false")
     public boolean dryRun;
 }

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/AbstractMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/AbstractMojo.java
@@ -61,6 +61,7 @@ abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo {
             }
         }
         return HawkEyeConfig.of(configLocation)
+                .dryRun(dryRun)
                 .addExcludes(submodulesExcludes)
                 .baseDir(basedir.toPath());
     }

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
@@ -51,9 +51,11 @@ public class CheckMojo extends AbstractMojo {
 
         if (missingHeaderFiles.isEmpty()) {
             log.info("No missing header file has been found.");
-        } else {
-            log.info("Found missing header files: %s".formatted(missingHeaderFiles));
-            throw new MojoFailureException("Found missing header files.");
+            return;
         }
+        for (String filename: missingHeaderFiles) {
+            log.error("Found missing header files: %s".formatted(filename));
+        }
+        throw new MojoFailureException("Found missing header files.");
     }
 }

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
@@ -27,12 +27,13 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
+@Mojo(name = "check", aggregator = true, defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class CheckMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoFailureException {
         final Log log = getLog();
-        log.info("Checking license headers... with cfg: %s".formatted(config));
+        log.info("Checking license headers... with config: %s".formatted(config));
+
         final HawkEyeConfig heConfig = HawkEyeConfig.of(config).build();
         final LicenseChecker checker = new LicenseChecker(heConfig);
         final Report report = checker.call();
@@ -41,7 +42,6 @@ public class CheckMojo extends AbstractMojo {
                 .filter(e -> ReportConstants.RESULT_UNKNOWN.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
-
         for (String unknownHeaderFile : unknownHeaderFiles) {
             log.warn("Processing unknown file: %s".formatted(unknownHeaderFile));
         }
@@ -50,14 +50,15 @@ public class CheckMojo extends AbstractMojo {
                 .filter(e -> ReportConstants.RESULT_MISSING.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
-
         if (missingHeaderFiles.isEmpty()) {
             log.info("No missing header file has been found.");
             return;
         }
+
         for (String missingHeaderFile : missingHeaderFiles) {
             log.error("Found missing header file: %s".formatted(missingHeaderFile));
         }
+
         throw new MojoFailureException("Missing header files found");
     }
 }

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
@@ -53,7 +53,7 @@ public class CheckMojo extends AbstractMojo {
             log.info("No missing header file has been found.");
             return;
         }
-        for (String filename: missingHeaderFiles) {
+        for (String filename : missingHeaderFiles) {
             log.error("Found missing header files: %s".formatted(filename));
         }
         throw new MojoFailureException("Found missing header files.");

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/CheckMojo.java
@@ -17,7 +17,6 @@
 package io.korandoru.hawkeye.maven.plugin;
 
 import io.korandoru.hawkeye.core.LicenseChecker;
-import io.korandoru.hawkeye.core.config.HawkEyeConfig;
 import io.korandoru.hawkeye.core.report.Report;
 import io.korandoru.hawkeye.core.report.ReportConstants;
 import java.util.List;
@@ -27,38 +26,34 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "check", aggregator = true, defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class CheckMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoFailureException {
         final Log log = getLog();
-        log.info("Checking license headers... with config: %s".formatted(config));
+        log.info("Checking license headers... with config: %s".formatted(configLocation));
 
-        final HawkEyeConfig heConfig = HawkEyeConfig.of(config).build();
-        final LicenseChecker checker = new LicenseChecker(heConfig);
+        final LicenseChecker checker = new LicenseChecker(configBuilder().build());
         final Report report = checker.call();
 
         final List<String> unknownHeaderFiles = report.getResults().entrySet().stream()
                 .filter(e -> ReportConstants.RESULT_UNKNOWN.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
-        for (String unknownHeaderFile : unknownHeaderFiles) {
-            log.warn("Processing unknown file: %s".formatted(unknownHeaderFile));
-        }
-
         final List<String> missingHeaderFiles = report.getResults().entrySet().stream()
                 .filter(e -> ReportConstants.RESULT_MISSING.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
+
+        if (!unknownHeaderFiles.isEmpty()) {
+            log.warn("Processing unknown files: %s".formatted(unknownHeaderFiles));
+        }
+
         if (missingHeaderFiles.isEmpty()) {
             log.info("No missing header file has been found.");
-            return;
+        } else {
+            log.info("Found missing header files: %s".formatted(missingHeaderFiles));
+            throw new MojoFailureException("Found missing header files.");
         }
-
-        for (String missingHeaderFile : missingHeaderFiles) {
-            log.error("Found missing header file: %s".formatted(missingHeaderFile));
-        }
-
-        throw new MojoFailureException("Missing header files found");
     }
 }

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/FormatMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/FormatMojo.java
@@ -17,7 +17,6 @@
 package io.korandoru.hawkeye.maven.plugin;
 
 import io.korandoru.hawkeye.core.LicenseFormatter;
-import io.korandoru.hawkeye.core.config.HawkEyeConfig;
 import io.korandoru.hawkeye.core.report.Report;
 import io.korandoru.hawkeye.core.report.ReportConstants;
 import java.util.List;
@@ -25,38 +24,34 @@ import java.util.Map;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "format", aggregator = true)
+@Mojo(name = "format")
 public class FormatMojo extends AbstractMojo {
     @Override
     public void execute() {
         final Log log = getLog();
-        log.info("Formatting license headers... with config: %s, dryRun: %s".formatted(config, dryRun));
+        log.info("Formatting license headers... with config: %s, dryRun: %s".formatted(configLocation, dryRun));
 
-        final HawkEyeConfig heConfig = HawkEyeConfig.of(config).dryRun(dryRun).build();
-        final LicenseFormatter checker = new LicenseFormatter(heConfig);
-        final Report report = checker.call();
+        final LicenseFormatter formatter = new LicenseFormatter(configBuilder().build());
+        final Report report = formatter.call();
 
         final List<String> unknownHeaderFiles = report.getResults().entrySet().stream()
                 .filter(e -> ReportConstants.RESULT_UNKNOWN.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
-        for (String unknownHeaderFile : unknownHeaderFiles) {
-            log.warn("Processing unknown file: %s".formatted(unknownHeaderFile));
-        }
 
         final List<Map.Entry<String, String>> updatedHeaderFiles = report.getResults().entrySet().stream()
                 .filter(e -> !ReportConstants.RESULT_UNKNOWN.equals(e.getValue()))
                 .filter(e -> !ReportConstants.RESULT_NOOP.equals(e.getValue()))
                 .toList();
-        if (updatedHeaderFiles.isEmpty()) {
-            log.info("All files have proper header.");
-            return;
+
+        if (!unknownHeaderFiles.isEmpty()) {
+            log.warn("Processing unknown files: %s".formatted(unknownHeaderFiles));
         }
 
-        if (!dryRun) {
-            for (Map.Entry<String, String> updatedHeaderFile : updatedHeaderFiles) {
-                log.info("Updated header for file: %s".formatted(updatedHeaderFile.getKey()));
-            }
+        if (updatedHeaderFiles.isEmpty()) {
+            log.info("All files have proper header.");
+        } else if (!dryRun) {
+            log.info("Updated header for files: %s".formatted(updatedHeaderFiles));
         }
     }
 }

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/FormatMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/FormatMojo.java
@@ -25,12 +25,12 @@ import java.util.Map;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "format")
+@Mojo(name = "format", aggregator = true)
 public class FormatMojo extends AbstractMojo {
     @Override
     public void execute() {
         final Log log = getLog();
-        log.info("Formatting license headers... with cfg: %s, dryRun: %s".formatted(config, dryRun));
+        log.info("Formatting license headers... with config: %s, dryRun: %s".formatted(config, dryRun));
 
         final HawkEyeConfig heConfig = HawkEyeConfig.of(config).dryRun(dryRun).build();
         final LicenseFormatter checker = new LicenseFormatter(heConfig);
@@ -40,7 +40,6 @@ public class FormatMojo extends AbstractMojo {
                 .filter(e -> ReportConstants.RESULT_UNKNOWN.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
-
         for (String unknownHeaderFile : unknownHeaderFiles) {
             log.warn("Processing unknown file: %s".formatted(unknownHeaderFile));
         }
@@ -49,7 +48,6 @@ public class FormatMojo extends AbstractMojo {
                 .filter(e -> !ReportConstants.RESULT_UNKNOWN.equals(e.getValue()))
                 .filter(e -> !ReportConstants.RESULT_NOOP.equals(e.getValue()))
                 .toList();
-
         if (updatedHeaderFiles.isEmpty()) {
             log.info("All files have proper header.");
             return;

--- a/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/RemoveMojo.java
+++ b/hawkeye-maven-plugin/src/main/java/io/korandoru/hawkeye/maven/plugin/RemoveMojo.java
@@ -25,12 +25,12 @@ import java.util.Map;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "remove")
+@Mojo(name = "remove", aggregator = true)
 public class RemoveMojo extends AbstractMojo {
     @Override
     public void execute() {
         final Log log = getLog();
-        log.info("Removing license headers... with cfg: %s, dryRun: %s".formatted(config, dryRun));
+        log.info("Removing license headers... with config: %s, dryRun: %s".formatted(config, dryRun));
 
         final HawkEyeConfig heConfig = HawkEyeConfig.of(config).dryRun(dryRun).build();
         final LicenseRemover remover = new LicenseRemover(heConfig);
@@ -40,7 +40,6 @@ public class RemoveMojo extends AbstractMojo {
                 .filter(e -> ReportConstants.RESULT_UNKNOWN.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
-
         for (String unknownHeaderFile : unknownHeaderFiles) {
             log.warn("Processing unknown file: %s".formatted(unknownHeaderFile));
         }
@@ -49,11 +48,11 @@ public class RemoveMojo extends AbstractMojo {
                 .filter(e -> ReportConstants.RESULT_REMOVED.equals(e.getValue()))
                 .map(Map.Entry::getKey)
                 .toList();
-
         if (removedHeaderFiles.isEmpty()) {
             log.info("No file has been removed header.");
             return;
         }
+
         if (!dryRun) {
             for (String removedHeaderFile : removedHeaderFiles) {
                 log.info("Removed header for file: %s".formatted(removedHeaderFile));

--- a/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/CheckMojoTest.java
+++ b/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/CheckMojoTest.java
@@ -31,7 +31,7 @@ class CheckMojoTest {
     @BeforeEach
     void setUp() {
         checkMojo = new CheckMojo();
-        checkMojo.config = new File("src/test/resources/t1.toml");
+        checkMojo.configLocation = new File("src/test/resources/t1.toml");
     }
 
     @Test

--- a/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/CheckMojoTest.java
+++ b/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/CheckMojoTest.java
@@ -49,6 +49,6 @@ class CheckMojoTest {
         tempFile.deleteOnExit();
         assertThatThrownBy(() -> checkMojo.execute())
                 .isExactlyInstanceOf(MojoFailureException.class)
-                        .hasMessage("Found missing header files.");
+                .hasMessage("Found missing header files.");
     }
 }

--- a/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/FormatMojoTest.java
+++ b/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/FormatMojoTest.java
@@ -33,7 +33,7 @@ class FormatMojoTest {
         tempFile = File.createTempFile("test", ".yaml", new File("src/test/resources"));
         assertTrue(tempFile.setWritable(true));
         formatMojo = new FormatMojo();
-        formatMojo.config = new File("src/test/resources/t1.toml");
+        formatMojo.configLocation = new File("src/test/resources/t1.toml");
     }
 
     @AfterEach

--- a/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/FormatMojoTest.java
+++ b/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/FormatMojoTest.java
@@ -16,36 +16,35 @@
 
 package io.korandoru.hawkeye.maven.plugin;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import org.junit.jupiter.api.AfterEach;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class FormatMojoTest {
     private FormatMojo formatMojo;
     private File tempFile;
 
+    @TempDir
+    private Path tempDir;
+
     @BeforeEach
     void setUp() throws IOException {
-        tempFile = File.createTempFile("test", ".yaml", new File("src/test/resources"));
-        assertTrue(tempFile.setWritable(true));
+        tempFile = File.createTempFile("test", ".yaml", tempDir.toFile());
         formatMojo = new FormatMojo();
+        formatMojo.basedir = tempDir.toFile();
         formatMojo.configLocation = new File("src/test/resources/t1.toml");
-    }
-
-    @AfterEach
-    void tearDown() {
-        assertTrue(tempFile.delete());
     }
 
     @Test
     void executeWithoutDryRun() throws IOException {
         formatMojo.execute();
         final String content = new String(Files.readAllBytes(tempFile.toPath()));
-        assertTrue(content.contains("Korandoru Contributors"));
+        assertThat(content).contains("Korandoru Contributors");
     }
 
     @Test
@@ -54,7 +53,6 @@ class FormatMojoTest {
         formatMojo.execute();
 
         final File formatedfile = new File(tempFile.getAbsolutePath() + ".formatted");
-        assertTrue(formatedfile.exists());
-        formatedfile.deleteOnExit();
+        assertThat(formatedfile).exists();
     }
 }

--- a/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/RemoveMojoTest.java
+++ b/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/RemoveMojoTest.java
@@ -62,7 +62,7 @@ class RemoveMojoTest {
         Files.write(path, header.getBytes());
 
         removeMojo = new RemoveMojo();
-        removeMojo.config = new File("src/test/resources/t2.toml");
+        removeMojo.configLocation = new File("src/test/resources/t2.toml");
     }
 
     @AfterEach

--- a/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/RemoveMojoTest.java
+++ b/hawkeye-maven-plugin/src/test/java/io/korandoru/hawkeye/maven/plugin/RemoveMojoTest.java
@@ -16,30 +16,26 @@
 
 package io.korandoru.hawkeye.maven.plugin;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class RemoveMojoTest {
     private RemoveMojo removeMojo;
     private File tempFile;
 
+    @TempDir
+    private Path tempDir;
+
     @BeforeEach
     void setUp() throws IOException {
-        final File testDir = new File("src/test/resources/test_remove");
-        if (!testDir.exists()) {
-            assertTrue(testDir.mkdirs());
-        }
-        testDir.deleteOnExit();
-        tempFile = File.createTempFile("test", ".yaml", testDir);
-        assertTrue(tempFile.setWritable(true));
+        tempFile = File.createTempFile("test", ".yaml", tempDir.toFile());
 
         final String header =
                 """
@@ -55,19 +51,16 @@ class RemoveMojoTest {
         # distributed under the License is distributed on an "AS IS" BASIS,
         # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
         # See the License for the specific language governing permissions and
-        # limitations under the License.""";
+        # limitations under the License.
+
+        name: testfile""";
 
         final Path path = Paths.get(tempFile.getAbsolutePath());
-
         Files.write(path, header.getBytes());
 
         removeMojo = new RemoveMojo();
+        removeMojo.basedir = tempDir.toFile();
         removeMojo.configLocation = new File("src/test/resources/t2.toml");
-    }
-
-    @AfterEach
-    void tearDown() {
-        assertTrue(tempFile.delete());
     }
 
     @Test
@@ -75,7 +68,8 @@ class RemoveMojoTest {
         removeMojo.execute();
 
         final String content = new String(Files.readAllBytes(tempFile.toPath()));
-        assertFalse(content.contains("Korandoru Contributors"));
+        assertThat(content).doesNotContain("Korandoru Contributors");
+        assertThat(content).contains("testfile");
     }
 
     @Test
@@ -84,7 +78,6 @@ class RemoveMojoTest {
         removeMojo.execute();
 
         final File formatedfile = new File(tempFile.getAbsolutePath() + ".removed");
-        assertTrue(formatedfile.exists());
-        formatedfile.deleteOnExit();
+        assertThat(formatedfile).exists();
     }
 }

--- a/hawkeye-maven-plugin/src/test/resources/t1.toml
+++ b/hawkeye-maven-plugin/src/test/resources/t1.toml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-baseDir = "."
-
 headerPath = "Apache-2.0.txt"
 
 excludes = [

--- a/hawkeye-maven-plugin/src/test/resources/t2.toml
+++ b/hawkeye-maven-plugin/src/test/resources/t2.toml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-baseDir = "src/test/resources/test_remove"
-
 headerPath = "Apache-2.0.txt"
 
 excludes = [

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,8 @@
         <slf4j.version>1.7.36</slf4j.version>
 
         <!-- plugin dependencies -->
-        <maven-plugin-api.version>3.9.4</maven-plugin-api.version>
-        <maven-plugin-annotation.version>3.9.0</maven-plugin-annotation.version>
-        <maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>
+        <maven-core.version>3.9.4</maven-core.version>
+        <maven-plugin-tools.version>3.9.0</maven-plugin-tools.version>
 
         <!-- bundled maven plugins -->
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>


### PR DESCRIPTION
This closes https://github.com/korandoru/hawkeye/issues/94.

But not exactly, cause Maven plugin inheritance (under multi-module project) is far more complicated then I ever think of.

For example, this patch works well if you configure the plugin in the parent module and run `mvn hawkeye:check`. But what if you want to bind it with VERIFY phase? The plugin will be inherited into all of the children modules and they will resolve relative path incorrectly. (Although we can support `skip` and skip at all the children modules as we do for the exec goal under the root pom.xml file in this project.)

We should spend some time to investigate what is the proper best practice here. And this PR serves as a reference instead of a mergeable patch.

cc @spencercjh 