### PR TITLE
fix: heuristic find header - blank lines after first comments should terminate

### DIFF
--- a/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/header/HeaderParser.java
+++ b/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/header/HeaderParser.java
@@ -179,7 +179,9 @@ public final class HeaderParser {
                 line = fileContent.nextLine();
             }
         }
-        if (headerDefinition.getEndLine().endsWith("EOL") && line != null && line.trim().isEmpty()) {
+        if (headerDefinition.getEndLine().endsWith("EOL")
+                && line != null
+                && line.trim().isEmpty()) {
             end = fileContent.getPosition();
         }
         return end;

--- a/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/header/HeaderParser.java
+++ b/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/header/HeaderParser.java
@@ -102,7 +102,6 @@ public final class HeaderParser {
                 // we detected previously a one line comment block that matches the header detection
                 // it is not a header it is a comment
                 return false;
-
             } else {
                 inPlaceHeader.append(line.toLowerCase());
             }
@@ -114,6 +113,8 @@ public final class HeaderParser {
 
             boolean foundEnd = false;
             if (headerDefinition.isMultipleLines() && headerDefinition.isLastHeaderLine(line)) {
+                foundEnd = true;
+            } else if (line.trim().isEmpty()) {
                 foundEnd = true;
             } else {
                 while ((line = fileContent.nextLine()) != null && line.startsWith(before)) {
@@ -131,7 +132,6 @@ public final class HeaderParser {
                     line = fileContent.nextLine();
                 } while (line != null && line.trim().isEmpty());
                 fileContent.rewind();
-
             } else if (!headerDefinition.isMultipleLines() && !foundEnd) {
                 fileContent.rewind();
             }

--- a/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/header/HeaderParser.java
+++ b/hawkeye-core/src/main/java/io/korandoru/hawkeye/core/header/HeaderParser.java
@@ -78,7 +78,7 @@ public final class HeaderParser {
 
     private boolean hasHeader() {
         // skip blank lines
-        while (line != null && "".equals(line.trim())) {
+        while (line != null && line.trim().isEmpty()) {
             line = fileContent.nextLine();
         }
         // check if there is already a header
@@ -91,7 +91,7 @@ public final class HeaderParser {
 
             // skip blank lines before header text
             if (headerDefinition.isAllowBlankLines()) {
-                while (line != null && "".equals(line.trim())) {
+                while (line != null && line.trim().isEmpty()) {
                     line = fileContent.nextLine();
                 }
             }
@@ -108,14 +108,13 @@ public final class HeaderParser {
             }
 
             String before = headerDefinition.getBeforeEachLine().stripTrailing();
-            if ("".equals(before) && !headerDefinition.isMultipleLines()) {
+            if (before.isEmpty() && !headerDefinition.isMultipleLines()) {
                 before = headerDefinition.getBeforeEachLine();
             }
 
             boolean foundEnd = false;
             if (headerDefinition.isMultipleLines() && headerDefinition.isLastHeaderLine(line)) {
                 foundEnd = true;
-
             } else {
                 while ((line = fileContent.nextLine()) != null && line.startsWith(before)) {
                     inPlaceHeader.append(line.toLowerCase());
@@ -130,7 +129,7 @@ public final class HeaderParser {
             if (headerDefinition.isMultipleLines() && headerDefinition.isAllowBlankLines() && !foundEnd) {
                 do {
                     line = fileContent.nextLine();
-                } while (line != null && "".equals(line.trim()));
+                } while (line != null && line.trim().isEmpty());
                 fileContent.rewind();
 
             } else if (!headerDefinition.isMultipleLines() && !foundEnd) {
@@ -143,7 +142,7 @@ public final class HeaderParser {
                 // check if the line is the end line
                 while (line != null
                         && !headerDefinition.isLastHeaderLine(line)
-                        && (headerDefinition.isAllowBlankLines() || !"".equals(line.trim()))
+                        && (headerDefinition.isAllowBlankLines() || !line.trim().isEmpty())
                         && line.startsWith(before)) {
                     line = fileContent.nextLine();
                 }
@@ -175,12 +174,12 @@ public final class HeaderParser {
         int end = fileContent.getPosition();
         line = fileContent.nextLine();
         if (beginPosition == 0) {
-            while (line != null && "".equals(line.trim())) {
+            while (line != null && line.trim().isEmpty()) {
                 end = fileContent.getPosition();
                 line = fileContent.nextLine();
             }
         }
-        if (headerDefinition.getEndLine().endsWith("EOL") && line != null && "".equals(line.trim())) {
+        if (headerDefinition.getEndLine().endsWith("EOL") && line != null && line.trim().isEmpty()) {
             end = fileContent.getPosition();
         }
         return end;

--- a/hawkeye-core/src/test/data/issue-110/.gitignore
+++ b/hawkeye-core/src/test/data/issue-110/.gitignore
@@ -1,0 +1,1 @@
+main.rs.formatted

--- a/hawkeye-core/src/test/data/issue-110/licenserc.toml
+++ b/hawkeye-core/src/test/data/issue-110/licenserc.toml
@@ -1,0 +1,11 @@
+baseDir = "src/test/data/issue-110"
+
+headerPath = "Apache-2.0.txt"
+
+includes = [
+    "*.rs",
+]
+
+[properties]
+inceptionYear = 2023
+copyrightOwner = "The CopyrightOwner"

--- a/hawkeye-core/src/test/data/issue-110/main.rs
+++ b/hawkeye-core/src/test/data/issue-110/main.rs
@@ -1,0 +1,5 @@
+// Copyright 2022-2023 The Authors. Licensed under Apache-2.0.
+
+//! Load balancer
+
+use macros::define_result;

--- a/hawkeye-core/src/test/data/issue-110/main.rs.formatted.expected
+++ b/hawkeye-core/src/test/data/issue-110/main.rs.formatted.expected
@@ -1,0 +1,17 @@
+// Copyright 2023 The CopyrightOwner
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Load balancer
+
+use macros::define_result;

--- a/hawkeye-core/src/test/java/io/korandoru/hawkeye/core/RegressionTest.java
+++ b/hawkeye-core/src/test/java/io/korandoru/hawkeye/core/RegressionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Korandoru Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.korandoru.hawkeye.core;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/hawkeye-core/src/test/java/io/korandoru/hawkeye/core/RegressionTest.java
+++ b/hawkeye-core/src/test/java/io/korandoru/hawkeye/core/RegressionTest.java
@@ -1,0 +1,20 @@
+package io.korandoru.hawkeye.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import io.korandoru.hawkeye.core.config.HawkEyeConfig;
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+public class RegressionTest {
+    @Test
+    void testIssue110() {
+        final File file = new File("src/test/data/issue-110/licenserc.toml");
+        final HawkEyeConfig config = HawkEyeConfig.of(file).dryRun(true).build();
+        final LicenseFormatter formatter = new LicenseFormatter(config);
+        formatter.call();
+
+        final File expected = new File("src/test/data/issue-110/main.rs.formatted.expected");
+        final File actual = new File("src/test/data/issue-110/main.rs.formatted");
+        assertThat(actual).hasSameTextualContentAs(expected);
+    }
+}

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -17,9 +17,10 @@ baseDir = "."
 headerPath = "Apache-2.0.txt"
 
 excludes = [
-    "**/*.txt",
-    "**/src/test/resources/**/*.toml",
-    "**/src/test/resources/**/*.xml",
+    "*.txt",
+    "hawkeye-core/src/test/resources/**/*.toml",
+    "hawkeye-core/src/test/resources/**/*.xml",
+    "hawkeye-core/src/test/data/**",
 ]
 
 [mapping.SCRIPT_STYLE]


### PR DESCRIPTION
This closes #110.

cc @tanruixiang @spencercjh 