### PR TITLE
feat: support `.mbt` extension for moonbit language

### DIFF
--- a/fmt/src/document/defaults.toml
+++ b/fmt/src/document/defaults.toml
@@ -307,7 +307,7 @@ extension = true
 filename = false
 
 [MOONBIT]
-pattert = "mbt"
+pattern = "mbt"
 headerType = "DOUBLESLASH_STYLE"
 extension = true
 filename = false

--- a/fmt/src/document/defaults.toml
+++ b/fmt/src/document/defaults.toml
@@ -306,6 +306,12 @@ headerType = "LUA"
 extension = true
 filename = false
 
+[MOONBIT]
+pattert = "mbt"
+headerType = "DOUBLESLASH_STYLE"
+extension = true
+filename = false
+
 [MUSTACHE]
 pattern = "mustache"
 headerType = "MUSTACHE_STYLE"


### PR DESCRIPTION
HI! 

Recently I have been focusing on a new programming language called Moonbit. It seems that moonbit's repository also needs a github action to check license header.

I happened to remember today that hawkeye was used in the greptime repository. So I just gave it a try.

Unfortunately, it seems that hawkeye currently does not know how to handle the moonbit code.