### PR TITLE
refactor: avoid the GitHelper and instead keep data on the stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,6 @@ version = "5.1.1"
 dependencies = [
  "gix",
  "ignore",
- "pathdiff",
  "regex",
  "serde",
  "snafu",
@@ -1093,12 +1092,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -25,7 +25,6 @@ repository.workspace = true
 [dependencies]
 gix = { version = "0.61", default-features = false, features = ["excludes"] }
 ignore = "0.4.22"
-pathdiff = "0.2.1"
 regex = "1.10.3"
 serde = { version = "1.0.197", features = ["derive"] }
 snafu.workspace = true

--- a/fmt/src/error.rs
+++ b/fmt/src/error.rs
@@ -123,13 +123,6 @@ pub enum Error {
         loc: snafu::Location,
     },
 
-    #[snafu(display("path not found {}", path))]
-    GixPathNotFount {
-        path: String,
-        #[snafu(implicit)]
-        loc: snafu::Location,
-    },
-
     #[snafu(display("cannot resolve absolute path {}: {}", path, source))]
     ResolveAbsolutePath {
         path: String,

--- a/fmt/src/selection.rs
+++ b/fmt/src/selection.rs
@@ -15,15 +15,15 @@
 use std::path::{Path, PathBuf};
 
 use ignore::overrides::OverrideBuilder;
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::{ensure, ResultExt};
 use tracing::debug;
 use walkdir::WalkDir;
 
 use crate::{
     config,
     error::{
-        GixCheckExcludeOpSnafu, GixExcludeOpSnafu, GixPathNotFountSnafu, ResolveAbsolutePathSnafu,
-        SelectFilesSnafu, SelectWithIgnoreSnafu, TraverseDirSnafu,
+        GixCheckExcludeOpSnafu, GixExcludeOpSnafu, ResolveAbsolutePathSnafu, SelectFilesSnafu,
+        SelectWithIgnoreSnafu, TraverseDirSnafu,
     },
     git, Result,
 };
@@ -118,7 +118,7 @@ fn select_files_with_ignore(
     reverse_excludes: &[String],
     turn_on_git_ignore: bool,
 ) -> Result<Vec<PathBuf>> {
-    debug!("Selecting files with ignore crate");
+    debug!(turn_on_git_ignore, "Selecting files with ignore crate");
     let mut result = vec![];
 
     let walker = ignore::WalkBuilder::new(basedir)
@@ -187,17 +187,13 @@ fn select_files_with_git(
         })?;
     let mut it = WalkDir::new(basedir).follow_links(false).into_iter();
 
-    let workdir = repo
-        .work_dir()
-        .context(GixPathNotFountSnafu { path: "workdir" })?;
+    let workdir = repo.work_dir().expect("workdir cannot be absent");
     let workdir = workdir
         .canonicalize()
         .with_context(|_| ResolveAbsolutePathSnafu {
             path: workdir.display().to_string(),
         })?;
-    let worktree = repo
-        .worktree()
-        .context(GixPathNotFountSnafu { path: "worktree" })?;
+    let worktree = repo.worktree().expect("worktree cannot be absent");
     let mut excludes = worktree
         .excludes(None)
         .map_err(Box::new)


### PR DESCRIPTION
This enables far-better performance.

Fixes #123

### Review Notes

I didn't actually test performance, and don't know how much tests would catch.
