### PR TITLE
fix: real header path should load

### DIFF
--- a/fmt/src/license/mod.rs
+++ b/fmt/src/license/mod.rs
@@ -14,9 +14,11 @@
 
 use snafu::ResultExt;
 
-use crate::config::Config;
-use crate::error::{InvalidConfigSnafu, LoadConfigSnafu};
-use crate::Result;
+use crate::{
+    config::Config,
+    error::{InvalidConfigSnafu, LoadConfigSnafu},
+    Result,
+};
 
 #[derive(Debug, Clone)]
 pub struct HeaderSource {

--- a/fmt/src/processor.rs
+++ b/fmt/src/processor.rs
@@ -17,7 +17,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::{ensure, ResultExt};
 use tracing::debug;
 
 use crate::{

--- a/fmt/src/processor.rs
+++ b/fmt/src/processor.rs
@@ -71,9 +71,7 @@ pub fn check_license_header<C: Callback>(run_config: PathBuf, callback: &mut C) 
     );
 
     let header_matcher = {
-        let header_source = HeaderSource::from_config(&config).context(InvalidConfigSnafu {
-            message: "no header source found in config",
-        })?;
+        let header_source = HeaderSource::from_config(&config)?;
         HeaderMatcher::new(header_source.content)
     };
 

--- a/tests/it.py
+++ b/tests/it.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2024 tison <wander4096@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,20 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-headerPath = "Apache-2.0.txt"
+from pathlib import Path
+import subprocess
 
-excludes = [
-    # Plain text files AS IS
-    "*.txt",
+basedir = Path(__file__).parent.absolute()
+rootdir = basedir.parent
 
-    # Test files
-    "fmt/tests/content/**",
-    "tests/load_header_path/**",
-
-    # Generated files
-    ".github/workflows/release.yml",
-]
-
-[properties]
-inceptionYear = 2024
-copyrightOwner = "tison <wander4096@gmail.com>"
+subprocess.run(["cargo", "build", "--bin", "hawkeye"], cwd=rootdir, check=True)
+hawkeye = rootdir / "target" / "debug" / "hawkeye"
+subprocess.run([hawkeye, "check"], cwd=(basedir / "load_header_path"), check=True)

--- a/tests/load_header_path/license.txt
+++ b/tests/load_header_path/license.txt
@@ -1,0 +1,11 @@
+Copyright ${inceptionYear} ${copyrightOwner}
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/load_header_path/licenserc.toml
+++ b/tests/load_header_path/licenserc.toml
@@ -1,0 +1,20 @@
+# Copyright 2024 Mike Delaney <dev@mldelaney.io>
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+baseDir = "."
+headerPath = "license.txt"
+
+excludes = [ ]
+
+[properties]
+inceptionYear = 2024
+copyrightOwner = "Mike Delaney <dev@mldelaney.io>"


### PR DESCRIPTION
cc @madelaney

This refers to https://github.com/korandoru/hawkeye/discussions/135.

Actually in the previous Java version, we can use resources path for predefined license header. And Discussion-135 is a good predefined BSD 3 Clause template. I'm thinking how we can build a proper bundled licenses loading logic instead of current:

```rust
pub fn bundled_headers(name: &str) -> Option<HeaderSource> {
    match name {
        "Apache-2.0.txt" => Some(HeaderSource {
            content: include_str!("Apache-2.0.txt").to_string(),
        }),
        "Apache-2.0-ASF.txt" => Some(HeaderSource {
            content: include_str!("Apache-2.0-ASF.txt").to_string(),
        }),
        _ => None,
    }
}
```

Or we can actually just append it ...