### PR TITLE
fix: always use path when handling path logics

### DIFF
--- a/fmt/src/document/factory.rs
+++ b/fmt/src/document/factory.rs
@@ -18,7 +18,7 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use snafu::ResultExt;
@@ -35,7 +35,7 @@ pub struct DocumentFactory {
     properties: HashMap<String, String>,
 
     keywords: Vec<String>,
-    git_file_attrs: HashMap<String, GitFileAttrs>,
+    git_file_attrs: HashMap<PathBuf, GitFileAttrs>,
     year_formatter: Vec<FormatItem<'static>>,
 }
 
@@ -45,7 +45,7 @@ impl DocumentFactory {
         definitions: HashMap<String, HeaderDef>,
         properties: HashMap<String, String>,
         keywords: Vec<String>,
-        git_file_attrs: HashMap<String, GitFileAttrs>,
+        git_file_attrs: HashMap<PathBuf, GitFileAttrs>,
     ) -> Self {
         let year_formatter = format_description::parse("[year]").expect("cannot parse format");
         Self {
@@ -86,10 +86,7 @@ impl DocumentFactory {
             .to_string();
         properties.insert("hawkeye.core.filename".to_string(), filename);
 
-        if let Some(attrs) = self
-            .git_file_attrs
-            .get(filepath.to_str().expect("path is never empty"))
-        {
+        if let Some(attrs) = self.git_file_attrs.get(filepath) {
             properties.insert(
                 "hawkeye.git.fileCreatedYear".to_string(),
                 attrs.created_time.format(self.year_formatter.as_slice()),

--- a/fmt/src/git.rs
+++ b/fmt/src/git.rs
@@ -18,7 +18,7 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
     convert::Infallible,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use gix::Repository;
@@ -98,7 +98,7 @@ pub struct GitFileAttrs {
 
 pub fn resolve_file_attrs(
     git_context: GitContext,
-) -> anyhow::Result<HashMap<String, GitFileAttrs>> {
+) -> anyhow::Result<HashMap<PathBuf, GitFileAttrs>> {
     let mut attrs = HashMap::new();
 
     if git_context.config.attrs.is_disable() {
@@ -130,9 +130,8 @@ pub fn resolve_file_attrs(
             &prev_commit.tree()?,
             &mut cache,
             |change| {
-                let filepath = workdir.join(change.location.to_string());
-                let filepath = filepath.display().to_string();
-
+                let filepath = gix::path::from_bstr(change.location);
+                let filepath = workdir.join(filepath);
                 match attrs.entry(filepath) {
                     Entry::Occupied(mut ent) => {
                         let attrs: &GitFileAttrs = ent.get();


### PR DESCRIPTION
Follow up @Byron's suggestion at https://github.com/korandoru/hawkeye/pull/150/files#r1634220929.