### PR TITLE
feat: Add support for `.jsx` files

### DIFF
--- a/fmt/src/document/defaults.toml
+++ b/fmt/src/document/defaults.toml
@@ -279,6 +279,12 @@ headerType = "XML_STYLE"
 extension = true
 filename = false
 
+[JSX]
+pattern = "jsx"
+headerType = "SLASHSTAR_STYLE"
+extension = true
+filename = false
+
 [KML]
 pattern = "kml"
 headerType = "XML_STYLE"


### PR DESCRIPTION
Hi there, great project you have here, it's really handy thanks.

I ran it against one of my repositories, and it was able to add headers for `.js`, `.ts` and `.tsx` files, but not `.jsx` files.

With the change in this PR, `.jsx` files get headers inserted in the same way as `.tsx` files.

I've tested it locally (via docker) and it works as intended.

Would be great to have this merged & released so I can update my Github action to also enforce this on JSX files.

Thanks again for this project, it's great