### PR TITLE
ci: use matrix build for multi-arch build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push-hawkeye-amd64:
-    runs-on: ubuntu-latest
+  build-and-push-hawkeye:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, buildjet-4vcpu-ubuntu-2204-arm]
+        arch: [amd64, arm64]
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: buildjet-4vcpu-ubuntu-2204-arm
+            arch: arm64
     permissions:
       packages: write
     steps:
@@ -37,30 +46,13 @@ jobs:
           name: hawkeye
           file: Dockerfile
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
-
-  build-and-push-hawkeye-arm64:
-    runs-on: buildjet-4vcpu-ubuntu-2204-arm
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build and push by digest
-        uses: ./.github/actions/docker-push-by-digest
-        id: build
-        with:
-          name: hawkeye
-          file: Dockerfile
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest-${{ matrix.arch }}: ${{ steps.build.outputs.digest }}
 
   release-hawkeye:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs:
-      - build-and-push-hawkeye-amd64
-      - build-and-push-hawkeye-arm64
+    needs: build-and-push-hawkeye
     steps:
       - uses: actions/checkout@v4
       - name: Merge and push manifest
@@ -68,16 +60,14 @@ jobs:
         with:
           name: hawkeye
           digests: >
-            ${{needs.build-and-push-hawkeye-amd64.outputs.digest}}
-            ${{needs.build-and-push-hawkeye-arm64.outputs.digest}}
+            ${{ needs.build-and-push-hawkeye.outputs.digest-amd64 }}
+            ${{ needs.build-and-push-hawkeye.outputs.digest-arm64 }}
 
   release-native:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs:
-      - build-and-push-hawkeye-amd64
-      - build-and-push-hawkeye-arm64
+    needs: build-and-push-hawkeye
     steps:
       - uses: actions/checkout@v4
       - name: Merge and push manifest
@@ -85,5 +75,5 @@ jobs:
         with:
           name: hawkeye-native
           digests: >
-            ghcr.io/${{ github.repository_owner }}/hawkeye@${{needs.build-and-push-hawkeye-amd64.outputs.digest}}
-            ghcr.io/${{ github.repository_owner }}/hawkeye@${{needs.build-and-push-hawkeye-arm64.outputs.digest}}
+            ghcr.io/${{ github.repository_owner }}/hawkeye@${{ needs.build-and-push-hawkeye.outputs.digest-amd64 }}
+            ghcr.io/${{ github.repository_owner }}/hawkeye@${{ needs.build-and-push-hawkeye.outputs.digest-arm64 }}


### PR DESCRIPTION
This simplifies your @actions config by replacing duplication with a matrix configuration.