### PR TITLE
feat: add Robot Framework support

### DIFF
--- a/fmt/src/document/defaults.toml
+++ b/fmt/src/document/defaults.toml
@@ -387,6 +387,18 @@ headerType = "SCRIPT_STYLE"
 extension = true
 filename = false
 
+[ROBOT_FRAMEWORK]
+pattern = "robot"
+headerType = "SCRIPT_STYLE"
+extension = true
+filename = false
+
+[ROBOT_FRAMEWORK_RESOURCE]
+pattern = "resource"
+headerType = "SCRIPT_STYLE"
+extension = true
+filename = false
+
 [RUBY]
 pattern = "rb"
 headerType = "SCRIPT_STYLE"


### PR DESCRIPTION
Add support for Robot Framework files with its two file extensions `.robot` and `.resource`.

See https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#supported-file-formats