### PR TITLE
feat: Support Pkl language

### DIFF
--- a/fmt/src/document/defaults.toml
+++ b/fmt/src/document/defaults.toml
@@ -354,6 +354,18 @@ headerType = "SCRIPT_STYLE"
 extension = true
 filename = false
 
+[PKL]
+pattern = "pkl"
+headerType = "LINE_BLOCK_STYLE"
+extension = true
+filename = false
+
+[PKL_PROJECT]
+pattern = "PklProject"
+headerType = "LINE_BLOCK_STYLE"
+extension = false
+filename = true
+
 [PHP]
 pattern = "php"
 headerType = "PHP"

--- a/fmt/src/header/defaults.toml
+++ b/fmt/src/header/defaults.toml
@@ -381,3 +381,14 @@ multipleLines = true
 padLines = false
 firstLineDetectionPattern = '(\s|\t)*<#--.*$'
 lastLineDetectionPattern = '.*-->(\s|\t)*$'
+
+[LINE_BLOCK_STYLE]
+firstLine = '//===----------------------------------------------------------------------===//'
+endLine = "//===----------------------------------------------------------------------===//\n"
+beforeEachLine = '// '
+afterEachLine = ''
+allowBlankLines = false
+multipleLines = true
+padLines = false
+firstLineDetectionPattern = '//\s?==='
+lastLineDetectionPattern = '//\s?==='


### PR DESCRIPTION
This change adds support for the `LINE_BLOCK_STYLE` license comment format, and applies it to `*.pkl` and `PklProject` files.

Structure
---------

The comment style is consistent with that of the Pkl project itself:

```
//===----------------------------------------------------------------------===//
// Copyright goes here.
//
// Lorem ipsum dolor sit amet.
//===----------------------------------------------------------------------===//
```

See: https://github.com/apple/pkl/blob/44fd680/stdlib/base.pkl