### PR TITLE
chore: improve unknown fields error report

### DIFF
--- a/fmt/src/config/mod.rs
+++ b/fmt/src/config/mod.rs
@@ -26,7 +26,7 @@ use toml::Value;
 use crate::default_true;
 
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
 pub struct Config {
     #[serde(default = "default_cwd")]
     pub base_dir: PathBuf,


### PR DESCRIPTION
This refers to https://github.com/korandoru/hawkeye/issues/175 where we can improve the error report as:

```
thread 'main' panicked at cli/src/subcommand.rs:106:52:
called `Result::unwrap()` on an `Err` value: cannot parse config file: licenserc.toml

Caused by:
    TOML parse error at line 39, column 2
       |
    39 | [mappings.LINE]
       |  ^^^^^^^^
    unknown field `mappings`, expected one of `baseDir`, `inlineHeader`, `headerPath`, `strictCheck`, `useDefaultExcludes`, `useDefaultMapping`, `keywords`, `includes`, `excludes`, `properties`, `mapping`, `git`, `additionalHeaders`
    
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Instead of silicently ignore unknown fields.