### PR TITLE
feat: add docker-based pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,3 +22,13 @@
   require_serial: true
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"
+- id: hawkeye-format-docker
+  name: hawkeye-format
+  description: "Run `hawkeye format` for license header formatting"
+  entry: hawkeye format
+  language: docker
+  args: []
+  pass_filenames: false
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"


### PR DESCRIPTION
On some machines, I struggle to get the regular hook to run due to the python build failing (it tries to build for MacOS from my WSL machine?), so this approach uses the Dockerfile that already exists to run hawkeye in an isolated environment.