### PR TITLE
feat: distribute builds for musl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,10 @@ installers = ["shell"]
 targets = [
   "aarch64-apple-darwin",
   "aarch64-unknown-linux-gnu",
+  "aarch64-unknown-linux-musl",
   "x86_64-apple-darwin",
   "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
   "x86_64-pc-windows-msvc",
 ]
 # Which actions to run on pull requests
@@ -68,6 +70,8 @@ install-path = "CARGO_HOME"
 [workspace.metadata.dist.github-custom-runners]
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
 aarch64-unknown-linux-gnu = "ubuntu-22.04-arm"
+x86_64-unknown-linux-musl = "ubuntu-22.04"
+aarch64-unknown-linux-musl = "ubuntu-22.04-arm"
 aarch64-apple-darwin = "macos-14"
 x86_64-apple-darwin = "macos-14"
 x86_64-pc-windows-msvc = "windows-2022"


### PR DESCRIPTION
This configures cargo-dist to also build against musl, which allows installing hawkeye on Alpine machines.